### PR TITLE
Fixed dev container rviz build error + mounting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,17 +6,20 @@
 			"WORKSPACE": "${containerWorkspaceFolder}"
 		}
 	},
-    // This will launch the container as a non-root user
-    "remoteUser" : "ros",
+    "remoteUser" : "root",
     "runArgs": [
          // This will allow you to use a ptrace-based debugger like C++, Go, and Rust.
-        "--network=host",
-		"--cap-add=SYS_PTRACE",
-		"--security-opt=seccomp:unconfined",
-		"--security-opt=apparmor:unconfined",
-		"--volume=/tmp/.X11-unix:/tmp/.X11-unix",
-		// "--volume=/mnt/wslg:/mnt/wslg",
-		"--ipc=host"
+	"--network=host",
+        "--cap-add=SYS_PTRACE",
+        "--security-opt=seccomp:unconfined",
+        "--security-opt=apparmor:unconfined",
+
+        // GUI support
+        "--env=DISPLAY=${localEnv:DISPLAY}",
+        "--volume=/tmp/.X11-unix:/tmp/.X11-unix:rw",
+
+        // Shared memory (needed for rqt, Foxglove bridge stability)
+        "--ipc=host"
     ],
     "containerEnv": {
 		"DISPLAY": "${localEnv:DISPLAY}", // Needed for GUI try ":0" for windows
@@ -43,5 +46,14 @@
 				"zachflower.uncrustify"
             ]
         }
-    }
+    },
+    "mounts": [
+        {
+            "type": "bind",
+            "source": "${localWorkspaceFolder}",
+            "target": "/root/AUV-2026"
+        }
+    ],
+
+    "workspaceFolder": "/root/AUV-2026"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,5 +65,8 @@
         ".vscode",
         ".vscode-insiders",
         ".devcontainer/devcontainer.json"
-    ]
+    ],
+    "ros.distro": "humble",
+    "python-envs.defaultEnvManager": "ms-python.python:system",
+    "python-envs.pythonProjects": []
 }

--- a/Docker/dev/Dockerfile
+++ b/Docker/dev/Dockerfile
@@ -1,36 +1,54 @@
 # Use the official ROS 2 Humble image as the base image
 FROM althack/ros2:humble-dev
 
-# Set up the environment
-ENV ROS_DISTRO=humble
+# Set up environment
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
-
 ENV DEBIAN_FRONTEND=noninteractive
+ENV ROS_DISTRO=humble
 
-# Install additional tools and dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    git \
-    python3-colcon-common-extensions \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install ROS 2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-humble-usb-cam \  
-    && rm -rf /var/lib/apt/lists/*
+    apt-utils \
+    build-essential \
+    cmake \
+    curl \
+    git \
+    git-lfs \
+    gnupg2 \
+    less \
+    lsb-release \
+    mesa-utils \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel \
+    python3-colcon-common-extensions \
+    python3-rosdep \
+    python3-vcstools \
+    sudo \
+    tar \
+    tmux \
+    v4l-utils usbutils \ 
+    vim \
+    wget \
+    x11-apps \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
 
-#TODO: add sbg driver (compile from source)
+# ROS packages 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+   ros-$ROS_DISTRO-joy \
+   ros-$ROS_DISTRO-joy-teleop \
+   ros-$ROS_DISTRO-foxglove-bridge \
+   ros-$ROS_DISTRO-mavros \
+   ros-$ROS_DISTRO-rviz2 \
+   && rm -rf /var/lib/apt/lists/* \
+   && apt-get clean
 
-# Create a workspace directory
-RUN mkdir -p /ros2_ws/src
+# Create workspace
+WORKDIR /root/AUV-2026
 
-# Set the working directory
-WORKDIR /ros2_ws
-
-# Source the ROS 2 setup file
-RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> /home/ros/.bashrc
-
-# Default command (starts a bash shell)
+RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> /root/.bashrc && \
+    echo "if [ -f /root/AUV-2026/ros2_ws/install/setup.bash ]; then source /root/AUV-2026/ros2_ws/install/setup.bash; fi" >> /root/.bashrc
 CMD ["bash"]


### PR DESCRIPTION
Problem: Dev container wasn't building 
Changes made:
- Removed ros-humble-rviz (does not exist) and replaced with the correct ros-humble-rviz2 package.
- Added dependencies from the  Jetson container. Some of them may be unnecessary/we might want other packages... 
- Added proper bind mounting of the AUV-2026 repo to simplify Git usage inside the container.
- Updated workspace folder handling so builds and sources happen in the correct place.