### PR TITLE
Minor but Urgent fix: Make jetson Docker container source appropriate ros2 setup.bash

### DIFF
--- a/Docker/jetson/Dockerfile
+++ b/Docker/jetson/Dockerfile
@@ -233,5 +233,5 @@ RUN pip install --extra-index-url ${PIP_INDEX_FOR_NON_NVIDIA} notebook \
 	pip install --ignore-install --upgrade typing_extensions
 
 # Source env variables
-RUN echo "source /opt/ros/humble/install/setup.bash && source /root/dependencies_ws/install/setup.bash && source /root/AUV-2026/ros2_ws/install/setup.bash" >> ~/.bashrc
+RUN echo "source /opt/ros/humble/setup.bash && source /root/dependencies_ws/install/setup.bash && source /root/AUV-2026/ros2_ws/install/setup.bash" >> ~/.bashrc
 CMD ["bash"]

--- a/Docker/jetson/README.md
+++ b/Docker/jetson/README.md
@@ -19,6 +19,22 @@ This repository contains a Dockerized ROS 2 Humble development environment for t
     docker exec -it jetson-douglas-1 bash
     ```
 
+## ⚠️ Warnings and pitfalls
+
+- When build the ROS package, make sure to source the ROS setup files first:
+    ```bash
+    source /opt/ros/humble/setup.bash
+    source /root/dependencies_ws/install/setup.bash
+    source /root/AUV-2026/ros2_ws/install/setup.bash
+    ```
+This is done by default when launching the container or opening a new bash shell. 
+
+**DO NOT** run `source /opt/ros/humble/install/setup.bash` (notice the additional `install` in the path). This ROS environment was generated when building ROS from source in the [`base image`](https://hub.docker.com/layers/dustynv/ros/humble-desktop-l4t-r36.4.0/images/sha256-b8ee30b1ae189cfeeea755a7fd6b8aea74267f5c1bc0cfa4f19a6acec9d941e5), and does not contain any of the installed packages (e.g. via `apt-get install`).
+
+- **OpenCV issue:**
+NVIDIA’s OpenCV version (4.10) which comes from dustynv's base image and provides CUDA acceleration are not the same as Ubuntu’s OpenCV version (4.5.4) Any ROS package that depends on vision_opencv (like cv-bridge, image-view) must be built from source against NVIDIA’s OpenCV. You can check the dependencies by running `apt-get install -s ros-humble-[package name]` inside the clean base container. Problematic packages will have a line like: Conf libopencv-core4.5d (4.5.4+dfsg-9ubuntu4 Ubuntu:22.04/jammy [arm64]).
+
+To address this issue, we are building all packages from source against NVIDIA's OpenCV version.
 ## 🏗️ Building from Source 
 
 This container is built upon the [`dustynv/ros:humble-desktop-l4t-r36.4.0`](https://hub.docker.com/layers/dustynv/ros/humble-desktop-l4t-r36.4.0/images/sha256-b8ee30b1ae189cfeeea755a7fd6b8aea74267f5c1bc0cfa4f19a6acec9d941e5) image. The core of our setup is derived from the [ZED ROS2 Wrapper Dockerfile](https://github.com/stereolabs/zed-ros2-wrapper/blob/master/docker/Dockerfile.l4t-humble), which we have extended with our own packages.
@@ -29,7 +45,4 @@ To rebuild the container from scratch, run the following command:
 docker compose build
 ```
 
-**OpenCV issue:**
-NVIDIA’s OpenCV version (4.10) which comes from dustynv's base image and provides CUDA acceleration are not the same as Ubuntu’s OpenCV version (4.5.4) Any ROS package that depends on vision_opencv (like cv-bridge, image-view) must be built from source against NVIDIA’s OpenCV. You can check the dependencies by running `apt-get install -s ros-humble-[package name]` inside the clean base container. Problematic packages will have a line like: Conf libopencv-core4.5d (4.5.4+dfsg-9ubuntu4 Ubuntu:22.04/jammy [arm64]).
 
-To address this issue, we are building all packages from source against NVIDIA's OpenCV version.


### PR DESCRIPTION
## Issue
* Sourcing the container from `/opt/ros/humble/install/setup.bash⁩` prevents the colcon from finding all required package (notably `rosidl_generator_cpp` to generate custom services and messages). 
* `/opt/ros/humble/install/⁩` is used to build ROS itself while `/opt/ros/humble/⁩` the packages are installed, but since we source from `/opt/ros/humble/install` [in this line of the container](https://github.com/mcgill-robotics/AUV-2026/commit/807948867b6d6a2f838928eb811a552e7b5d073f#diff-f20543f1c0618a14daec98c46e200aca01595286db19c7e5c27a82ac6176c191L236), `colcon build` is unable to find `rosidl_generator_cpp` and fails.

## Fix
Replace `source /opt/ros/humble/install/setup.bash` with `source /opt/ros/humble/setup.bash` in the `.bashrc` so that *only* `/opt/ros/humble` is sourced. Unsure why this issue only pops up now but this will be tested. For now we add this fix to allow the jetson build ROS packages on the `main` branch