### PR TITLE
Hotfix: Run privileged commands as sudo inside docker container

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -97,6 +97,7 @@ jobs:
     - name: Run colcon build in container
       run: |
         docker run --rm \
+          --user $(id -u):$(id -g) \
           -v ${{ github.workspace }}:/workspace \
           -w /workspace \
           mcgillrobotics/auv_2026:dev-arm64 \


### PR DESCRIPTION
This pull request makes a minor update to the build workflow configuration, ensuring that dependency installation commands are run with `sudo` for proper permissions.

## Motivation
Since #45, development and jetson docker containers are run as user (douglas) instead of root. Previously when developing the CI (see #22), docker container were assumed to be run as root, and so privileged command could be run. Note that this issue occurs in CI tests that pull directly from the dockerhub, which only hosts images on the main branch. This is why this issue was not be caught when testing #45. 

## Changes
  * Changed `apt-get update` and `rosdep install` commands to use `sudo` in `.github/workflows/build-main.yaml`, ensuring they have the necessary privileges during CI builds.
  * Made user that runs the docker container match the CI runner UID and GID. This allows the runner to write to the `build` `install` `log` files which were previously owned by the douglas user