### PR TITLE
Hotfix: Configure debug build for sequential compilation and swapfile actions

### DIFF
--- a/.github/actions/swapfile/action.yaml
+++ b/.github/actions/swapfile/action.yaml
@@ -12,6 +12,17 @@ runs:
         df -h /
         echo "-- Memory & Swap --"
         free -h
+        
+        # Clean up any leftover swapfile from a previous run
+        if swapon --show | grep -q /swapfile; then
+          echo "Existing swapfile is active, disabling it..."
+          sudo swapoff /swapfile
+        fi
+        if [ -f /swapfile ]; then
+          echo "Existing swapfile found on disk, removing it..."
+          sudo rm /swapfile
+        fi
+
         # awk extracts line 2, column 4 (available space in root filesystem)
         AVAILABLE_MB=$(df -m / | awk 'NR==2 {print $4}')
         # allocate 40% of available disk space

--- a/.github/actions/swapfile/action.yaml
+++ b/.github/actions/swapfile/action.yaml
@@ -1,0 +1,44 @@
+name: Add Swapfile
+description: Github actions runners have very limited RAM (~8GB) which causes docker builds to fail with OOM errors. This action adds a (at most) 4GB swapfile to increase available memory and prevent OOM issues during builds.
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      name: Add Swapfile
+      run: |
+        echo "=== Before ==="
+        echo "-- Disk --"
+        df -h /
+        echo "-- Memory & Swap --"
+        free -h
+        # awk extracts line 2, column 4 (available space in root filesystem)
+        AVAILABLE_MB=$(df -m / | awk 'NR==2 {print $4}')
+        # allocate 40% of available disk space
+        SWAP_MB=$(( AVAILABLE_MB * 40 / 100 ))
+        # cap swap at 4GB to avoid excessive disk usage
+        SWAP_MB=$(( SWAP_MB > 4096 ? 4096 : SWAP_MB ))
+
+        echo ""
+        echo "Disk available: ${AVAILABLE_MB}MB"
+        echo "Swap to allocate: ${SWAP_MB}MB"
+        echo ""
+
+        # a swapfile smaller than 512mb is not worth creating
+        if [ "$SWAP_MB" -ge 512 ]; then
+          echo "Allocating ${SWAP_MB}MB swapfile at /swapfile..."
+          sudo fallocate -l ${SWAP_MB}M /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          echo "Swap enabled."
+        else
+          echo "Only ${SWAP_MB}MB available for swap — skipping (below 512MB threshold)."
+        fi
+
+        echo ""
+        echo "=== After ==="
+        echo "-- Disk --"
+        df -h /
+        echo "-- Memory & Swap --"
+        free -h

--- a/.github/workflows/docker-images-main.yml
+++ b/.github/workflows/docker-images-main.yml
@@ -135,6 +135,8 @@ jobs:
           tags: ${{ env.PRIMARY_TAG }}
           build-args: |
             CI=true
+      
+      - uses: ./.github/actions/swapfile
 
       - name: Verify Build
         run: |
@@ -159,6 +161,18 @@ jobs:
           else:
               print('CPU container, skipping CUDA check.')
           "
+      - name: Teardown swap space
+        if: always()
+        run: |
+          if swapon --show | grep -q /swapfile; then
+            echo "Disabling and removing swapfile..."
+            sudo swapoff /swapfile
+            sudo rm /swapfile
+            echo "Done. Disk reclaimed:"
+            df -h /
+          else
+            echo "No swapfile found, nothing to clean up."
+          fi
 
       - name: Push image
         if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}

--- a/.github/workflows/docker-images-main.yml
+++ b/.github/workflows/docker-images-main.yml
@@ -66,7 +66,8 @@ jobs:
           submodules: recursive
           lfs: true
 
-      - uses: ./.github/actions/cleanup_disk
+      - name: Clean up Disk Space
+        uses: ./.github/actions/cleanup_disk
 
       - name: Set Docker Tags
         id: docker_tags
@@ -136,7 +137,8 @@ jobs:
           build-args: |
             CI=true
       
-      - uses: ./.github/actions/swapfile
+      - name: Add Swapfile
+        uses: ./.github/actions/swapfile
 
       - name: Verify Build
         run: |

--- a/build.sh
+++ b/build.sh
@@ -200,6 +200,9 @@ if [ "$OFFLINE_BUILD" = true ]; then
 fi
 
 if [ "$DEBUG_BUILD" = true ]; then
+    (
+    # wrap in parens to limit scope of env var change to just the colcon build command
+    export CMAKE_BUILD_PARALLEL_LEVEL=1
     echo "    -> Performing Debug Build of packages: ${PKGS[*]}"
     # Output to console, interleaving build output for better visibility
     # Generate compile commands for use with linters e.g. VSCode
@@ -214,6 +217,7 @@ if [ "$DEBUG_BUILD" = true ]; then
             -DIS_JETSON_CI=$IS_JETSON_CI \
             $OFFLINE_CMAKE_ARGS \
         $([ -n "$PACKAGE_TO_BUILD" ] && echo "--packages-up-to $PACKAGE_TO_BUILD")
+    )
 else
     echo "    -> Performing Release Build of packages: ${PKGS[*]}"
     # Output with cohesion, groups output by package

--- a/build.sh
+++ b/build.sh
@@ -207,6 +207,7 @@ if [ "$DEBUG_BUILD" = true ]; then
     colcon build \
         --event-handlers console_direct+ \
         --executor sequential \
+        --parallel-workers 1 \
         --cmake-args \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo  \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \

--- a/build.sh
+++ b/build.sh
@@ -206,12 +206,12 @@ if [ "$DEBUG_BUILD" = true ]; then
     # Run everything sequentially to find exact failure point
     colcon build \
         --event-handlers console_direct+ \
+        --executor sequential \
         --cmake-args \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo  \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DIS_JETSON_CI=$IS_JETSON_CI \
             $OFFLINE_CMAKE_ARGS \
-        --executor sequential \
         $([ -n "$PACKAGE_TO_BUILD" ] && echo "--packages-up-to $PACKAGE_TO_BUILD")
 else
     echo "    -> Performing Release Build of packages: ${PKGS[*]}"


### PR DESCRIPTION
This pull request adds multiple measures to reduce the memory usage on the CI runner similar to the disk space cleanup that is done in #45 

## Motivation
The controls package (#44 ) introduces multiple C++ files that, during the colcon build phase of the CI, consume more memory than is available in the free Github Actions Runner. 

## Changes
### Github Actions
* Added a new composite GitHub Action that creates a swapfile of up to 4GB based on available disk space, to prevent OOM errors during Docker builds. The action includes logic to clean up any leftover swapfile from previous runs (by default the runner has a 2GB swapfile) and only allocates swap if at least 512MB is available.

### Build script
* Modified the debug build process in `build.sh` to enforce sequential builds and limit parallelism. This enforces that packages are built one and at a time and source files are compiled one at a time, reducing memory overhead

## Tests done
Passes CI

## Moving forward
This is a band-aid fix, as we introduce more complex and heavy packages we may still hit the 4GB swapfile limit, in which case we should look into more memory efficient compilation options, or to increase the runner resources if possible.