### PR TITLE
Hotfix: Pin foxglove git clone to prevent failing build

### DIFF
--- a/Docker/dev/Dockerfile
+++ b/Docker/dev/Dockerfile
@@ -133,7 +133,7 @@ RUN . /opt/ros/${ROS_DISTRO}/setup.sh && \
 # Install Foxglove Bridge from source
 # ----------------------------------------------------------
 WORKDIR /opt/ros/foxglove_ws
-RUN git clone https://github.com/foxglove/foxglove-sdk.git src/foxglove-sdk && \
+RUN git clone --depth 1 --branch sdk/v0.21.0 https://github.com/foxglove/foxglove-sdk.git src/foxglove-sdk && \
     apt-get update && \
     rm -rf /etc/ros/rosdep/sources.list.d/* && \
     rosdep init && \

--- a/Docker/dev/Dockerfile.nvidia
+++ b/Docker/dev/Dockerfile.nvidia
@@ -170,7 +170,7 @@ RUN . /opt/ros/${ROS_DISTRO}/setup.sh && \
 # ----------------------------------------------------------
 WORKDIR /opt/ros/foxglove_ws
 RUN git clone --depth 1 --branch sdk/v0.21.0 https://github.com/foxglove/foxglove-sdk.git src/foxglove-sdk && \
-        apt-gepdate && \
+        apt-get update && \
         rm -rf /etc/ros/rosdep/sources.list.d/* && \
         rosdep init && \
         rosdep update --rosdistro ${ROS_DISTRO} && \

--- a/Docker/dev/Dockerfile.nvidia
+++ b/Docker/dev/Dockerfile.nvidia
@@ -169,8 +169,8 @@ RUN . /opt/ros/${ROS_DISTRO}/setup.sh && \
 # Install Foxglove Bridge from source
 # ----------------------------------------------------------
 WORKDIR /opt/ros/foxglove_ws
-RUN git clone https://github.com/foxglove/foxglove-sdk.git src/foxglove-sdk && \
-        apt-get update && \
+RUN git clone --depth 1 --branch sdk/v0.21.0 https://github.com/foxglove/foxglove-sdk.git src/foxglove-sdk && \
+        apt-gepdate && \
         rm -rf /etc/ros/rosdep/sources.list.d/* && \
         rosdep init && \
         rosdep update --rosdistro ${ROS_DISTRO} && \

--- a/Docker/jetson/Dockerfile
+++ b/Docker/jetson/Dockerfile
@@ -265,7 +265,7 @@ RUN . /opt/ros/$ROS_DISTRO/install/setup.bash && \
 # Install Foxglove Bridge from source
 # ----------------------------------------------------------
 WORKDIR /opt/ros/foxglove_ws
-RUN git clone https://github.com/foxglove/foxglove-sdk.git src/foxglove-sdk && \
+RUN git clone --depth 1 --branch sdk/v0.21.0 https://github.com/foxglove/foxglove-sdk.git src/foxglove-sdk && \
     apt-get update && \
     rm -rf /etc/ros/rosdep/sources.list.d/* && \
     rosdep init && \


### PR DESCRIPTION
### 
> **_[Pin git clone to sdk/v0.21.0 tag, which works.](https://github.com/mcgill-robotics/AUV-2026/pull/100)_**